### PR TITLE
Add elasticsearch profile to uitpas::website role

### DIFF
--- a/manifests/uitpas/website.pp
+++ b/manifests/uitpas/website.pp
@@ -2,7 +2,7 @@ class roles::uitpas::website inherits ::roles::base {
 
   include profiles::nodejs
   include profiles::php
-  # include profiles::elasticsearch
+  include profiles::elasticsearch
   include profiles::uitpas::website::frontend
   include profiles::uitpas::website::api
 }


### PR DESCRIPTION
elasticsearch-readonlyrest package has been fixed and re-added to aptly.
this include should no longer break the puppetrun.