### PR TITLE
Enables RDS backup functionality

### DIFF
--- a/manifests/backupserver.pp
+++ b/manifests/backupserver.pp
@@ -1,4 +1,5 @@
 class roles::backupserver inherits roles::base {
 
   include profiles::backup::server
+  include profiles::backup::rds
 }


### PR DESCRIPTION
This pull request includes a small change to the `manifests/backupserver.pp` file. The change adds `profiles::backup::rds` to the list of included profiles in the `roles::backupserver` class.