### PR TITLE
add uitid-mailing role

### DIFF
--- a/manifests/uitid/mailing.pp
+++ b/manifests/uitid/mailing.pp
@@ -1,0 +1,6 @@
+class roles::uitid::mailing inherits ::roles::base {
+
+  include profiles::java
+  include profiles::glassfish
+  include profiles::uitid::mailing
+}


### PR DESCRIPTION
This pull request introduces a new Puppet class to define the `roles::uitid::mailing` role, which inherits from the base role and includes the necessary profiles for Java, GlassFish, and the `uitid::mailing` service.

Key change:

* [`manifests/uitid/mailing.pp`](diffhunk://#diff-832c4863c4cab119fa5e711c815ca1031b408a60ebaf2fae57475119ced4ca96R1-R6): Added the `roles::uitid::mailing` class, inheriting from `roles::base` and including `profiles::java`, `profiles::glassfish`, and `profiles::uitid::mailing`.