### PR TITLE
Add python to base role

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -14,6 +14,7 @@ class roles::base inherits roles {
   include profiles::ntp
   include profiles::postfix
   include profiles::puppet::agent
+  include profiles::python
   include profiles::rsyslog
   include profiles::ruby
   include profiles::ssh


### PR DESCRIPTION
As python is installed in the base image anyway, it makes sense to include it in the base role so we can manage it through hiera.