### PR TITLE
The awscli declaration is now a package declaration, not a class

### DIFF
--- a/manifests/jenkins/agent.pp
+++ b/manifests/jenkins/agent.pp
@@ -6,6 +6,4 @@ class roles::jenkins::agent inherits roles::base {
   include profiles::php
   include profiles::nodejs
   include profiles::docker
-  include profiles::aws_cli
-  
 }


### PR DESCRIPTION
The awscli package is now added like the other homebuilt packages, and the
packages profile is extended to allow specifying versions for all packages
defined therein. The aws_cli is now unneeded.
