### PR TITLE
[OPS-1550]: add search_docker role without php profile

### DIFF
--- a/manifests/uitdatabank/search_docker.pp
+++ b/manifests/uitdatabank/search_docker.pp
@@ -1,0 +1,9 @@
+class roles::uitdatabank::search_docker inherits ::roles::base {
+
+  include profiles::java
+  include profiles::apache
+  include profiles::redis
+  include profiles::elasticsearch
+  include profiles::uitdatabank::search_api
+  include profiles::uitdatabank::search_api::data_integration
+}


### PR DESCRIPTION
### Added

- New role for uitdatabank::search_docker, which is the same as uitdatabank::search, but doesn't include php.
- Normally it should be safe to remove the php profile from the search role, since it's added by the deployment profile when the `type` is `instance`, but to be extra cautious I preferred duplicating it

### Changed

-

### Removed

-

### Fixed

-

---
Ticket: https://jira.uitdatabank.be/browse/...
